### PR TITLE
Removes Metapsionic Pulse and Dispel from the Rollable Pool

### DIFF
--- a/Resources/Prototypes/Psionics/PsionicPowerPool.yml
+++ b/Resources/Prototypes/Psionics/PsionicPowerPool.yml
@@ -1,9 +1,7 @@
 - type: weightedRandom
   id: RandomPsionicPowerPool
   weights:
-    MetapsionicPower: 0.25 # Leads to Assay
     AnoigoPower: 0.25
-    DispelPower: 0.5
     TelegnosisPower: 0.5
     PsionicRegenerationPower: 0.75
     MassSleepPower: 0.5


### PR DESCRIPTION
Metapsionic pulse is broken and dispel is mostly useless, remade this PR because I was a stupid idiot on how I was doing PRs 